### PR TITLE
Document simple and build project flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ To see technology used as a tool for service, collaboration, and Gospel-centered
 
 ## 🧩 How It Works
 
-1. **Organizations submit a project idea or need**  
-   (websites, apps, internal tools, data solutions, etc.)
+1. **Organizations submit a project idea or need**
+   - **Simple requests** (no repo): e.g., update donor lists, set up livestreams, configure tools.
+   - **Build projects** (with repo): e.g., ministry websites, mobile apps, data pipelines.
 
-2. **A GitHub repository is created or linked**  
+2. **A GitHub repository is created or linked for build projects**
    With clear goals, issues, and contribution guidelines.
 
-3. **Developers join and collaborate**  
+3. **Developers join and collaborate**
    By picking issues, submitting PRs, and building together.
 
-4. **Impact is delivered**  
-   Through usable software that serves people and ministries.
+4. **Impact is delivered**
+   Through usable software or completed service work that serves people and ministries.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -286,6 +286,21 @@
   <section id="submit" aria-labelledby="submit-title">
     <div class="container">
       <h2 id="submit-title">Submit a project</h2>
+      <p class="meta" style="margin-bottom:1rem">Pick the path that fits your need—quick service requests or full build projects.</p>
+      <div class="grid cards" style="margin-bottom:1.2rem">
+        <article class="card">
+          <div class="chip">Simple request</div>
+          <h3>Service / setup help</h3>
+          <p>Examples: clean up a donor list, set up livestreaming, configure forms, or organize existing tools. No code repo needed.</p>
+          <p class="meta">Deliverables: checklists, call notes, configs, or training docs.</p>
+        </article>
+        <article class="card">
+          <div class="chip">Build a product</div>
+          <h3>Code & deploy</h3>
+          <p>Examples: launch a ministry site, build a web/app experience, or create a data pipeline. We can seed or link a GitHub repo with issues and labels.</p>
+          <p class="meta">Deliverables: repository, issues, milestones, and deployment plan.</p>
+        </article>
+      </div>
       <form id="submitForm" class="card" novalidate>
         <label><span>Organization or ministry *</span><input name="org" required placeholder="e.g., Hope Community Center" /></label>
         <label><span>Project title *</span><input name="title" required placeholder="e.g., Volunteer Scheduling App" /></label>


### PR DESCRIPTION
## Summary
- add simple-request vs build-project guidance to the submit section on the site
- update README workflow to reflect both non-repo and repo-based tracks

## Testing
- not run (documentation-only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457b9e45ac8327ab279ac8ff042c42)