### PR TITLE
Style project type selector

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -156,7 +156,7 @@
     :focus-visible { outline: 3px solid color-mix(in srgb,var(--accent) 55%, transparent); outline-offset: 2px; }
 
     /* inputs */
-    input, textarea, select {
+    input:not([type="radio"]):not([type="checkbox"]), textarea, select {
       width: 100%;
       margin-top: .35rem;
       padding: .75rem .85rem;
@@ -166,7 +166,30 @@
       color: var(--text);
       box-shadow: inset 0 0 0 1px rgba(255,255,255,.03);
     }
+    input[type="radio"], input[type="checkbox"] {
+      width: 1.1rem;
+      height: 1.1rem;
+      margin: 0;
+      accent-color: var(--accent);
+      filter: drop-shadow(0 0 4px rgba(112,166,153,.35));
+    }
     label span { color: var(--muted); font-size: .95rem; }
+
+    .option-pills { display:flex; gap:.9rem; flex-wrap:wrap; align-items:center; }
+    .option-pill {
+      display:flex;
+      gap:.5rem;
+      align-items:center;
+      padding:.7rem .9rem;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(20,20,47,.85);
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,.02);
+      cursor: pointer;
+      transition: border-color .18s ease, box-shadow .18s ease, background .18s ease, transform .18s ease;
+    }
+    .option-pill:hover { border-color: color-mix(in srgb,var(--accent) 35%, var(--border)); box-shadow: var(--glow); transform: translateY(-1px); }
+    .option-pill span { color: var(--text); font-weight: 700; letter-spacing: .01em; }
 
     .bezel { border: 1px solid var(--border); border-radius: 18px; background: rgba(12,11,28,.9); box-shadow: var(--glow); position: relative; overflow: hidden; }
     .bezel::before { content:""; position:absolute; inset:0; background:linear-gradient(90deg, rgba(232,115,36,.12), transparent 25%, rgba(112,166,153,.12) 60%, transparent 80%); opacity:.7; pointer-events:none; }
@@ -304,12 +327,14 @@
       <form id="submitForm" class="card" novalidate>
         <fieldset style="border:none; padding:0; margin:0 0 1rem;">
           <legend style="color:var(--title); font-weight:700; margin-bottom:.35rem;">Project type *</legend>
-          <div style="display:flex; gap:.9rem; flex-wrap:wrap; align-items:center;">
-            <label style="display:flex; gap:.35rem; align-items:center;">
-              <input type="radio" name="projectType" value="service" checked /> <span>Service / setup help</span>
+          <div class="option-pills">
+            <label class="option-pill">
+              <input type="radio" name="projectType" value="service" checked />
+              <span>Service / setup help</span>
             </label>
-            <label style="display:flex; gap:.35rem; align-items:center;">
-              <input type="radio" name="projectType" value="build" /> <span>Build a product</span>
+            <label class="option-pill">
+              <input type="radio" name="projectType" value="build" />
+              <span>Build a product</span>
             </label>
           </div>
           <p id="typeHint" class="meta" style="margin:.45rem 0 0;">Great for quick help like cleaning lists, setting up livestreaming, or organizing existing tools.</p>


### PR DESCRIPTION
## Summary
- exclude radio and checkbox inputs from text field styling to keep consistent sizing
- style project type selector as pill options that match the page's visual language

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458337ce588327aaf52115bb26c37d)