### PR TITLE
Fix console intro text alignment

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -126,7 +126,7 @@
     .console-line { color: #9fe3ce; font-size: .95rem; display: flex; gap: .6rem; align-items: center; }
     .prompt { color: #e87324; }
     .blink { animation: blink 1.1s steps(2, start) infinite; }
-    .console-body { display: grid; gap: .7rem; justify-items: start; }
+    .console-body { display: grid; gap: .7rem; justify-items: start; text-align: left; }
     .console-shell { width: min(900px, 100%); margin-inline: auto; padding: 1.4rem; display: grid; gap: .9rem; }
     .hero .stat-stack { width: min(900px, 100%); margin-inline: auto; }
     .stat-stack { display: grid; gap: .6rem; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); margin-top: 1rem; }


### PR DESCRIPTION
## Summary
- align console body text left to match the console layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694588de0f108327ae39255e952718a4)