### PR TITLE
Add favicon to documentation site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
   <title>CrossCollab – Code with purpose. Build for the Kingdom.</title>
   <meta name="description" content="CrossCollab connects ministries, NGOs, and churches with Christian technologists to build open‑source tools that serve real needs." />
   <meta name="theme-color" content="#211F46" />
+  <link rel="icon" type="image/png" href="./assets/img/favicon.png" />
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 
   <style>


### PR DESCRIPTION
## Summary
- add link tag in docs site head to use the provided favicon asset as the tab icon

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458d93ade48327bd9188f50138a878)